### PR TITLE
Customized transaction type (pre-post eip 1559) based on chain id

### DIFF
--- a/packages/bundler/src/UserOpMethodHandler.ts
+++ b/packages/bundler/src/UserOpMethodHandler.ts
@@ -155,6 +155,7 @@ export class UserOpMethodHandler {
   }
 
   async sendUserOperation (userOp1: UserOperationStruct, entryPointInput: string): Promise<string> {
+    console.log("userOp1:", userOp1, "entryPoint:", entryPointInput);  
     await this._validateParameters(userOp1, entryPointInput)
 
     const userOp = await resolveProperties(userOp1)

--- a/packages/bundler/src/modules/BundleManager.ts
+++ b/packages/bundler/src/modules/BundleManager.ts
@@ -102,7 +102,7 @@ export class BundleManager {
     feeData: FeeData;
   }): Promise<PopulatedTransaction> {
     switch (props.chainId) {
-      case "0x1" || "1":
+      case "1":
         return await this.entryPoint.populateTransaction.handleOps(props.userOps, props.beneficiary, {
           type: 2,
           nonce: await this.signer.getTransactionCount(),
@@ -110,14 +110,14 @@ export class BundleManager {
           maxPriorityFeePerGas: props.feeData.maxPriorityFeePerGas ?? 0,
           maxFeePerGas: props.feeData.maxFeePerGas ?? 0
         });
-      case "0x89" || "137":
+      case "137":
         //non-eip1559 transaction
         return await this.entryPoint.populateTransaction.handleOps(props.userOps, props.beneficiary, {
           nonce: await this.signer.getTransactionCount(),
           gasLimit: this.getGasLimit(props.chainId),
           gasPrice: props.feeData.gasPrice ?? 0,
         })
-      case "0xa4b1" || "42161":
+      case "42161":
         return await this.entryPoint.populateTransaction.handleOps(props.userOps, props.beneficiary, {
           type: 2,
           nonce: await this.signer.getTransactionCount(),

--- a/packages/bundler/src/modules/BundleManager.ts
+++ b/packages/bundler/src/modules/BundleManager.ts
@@ -126,7 +126,7 @@ export class BundleManager {
           maxFeePerGas: props.feeData.maxFeePerGas ?? 0
         });
       default:
-        throw new Error("Unsupported chain id: + chainId");
+        throw new Error("Unsupported chain id: " + props.chainId);
     }
   }
 


### PR DESCRIPTION
This was introduced to address some `underpriced transaction` errors occurring in some RPC nodes when using eip 1559 transactions.